### PR TITLE
Upgrade Java version to 25.0.4_7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,7 +49,7 @@ java_options: "{{ base_java_options + extra_java_options + enabled_otel_java_opt
 
 __server_port: 8081
 
-__java_version: 17.0.18_8
+__java_version: 25.0.4_7
 
 # 
 


### PR DESCRIPTION
Upgrades the Java version to **25.0.4_7** to standardize on a single version across all Ansible roles.

- Updated `__java_version` in `defaults/main.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)